### PR TITLE
Add 'digest_alg' to fix certificate issues

### DIFF
--- a/pfSense/pfSense.psm1
+++ b/pfSense/pfSense.psm1
@@ -225,6 +225,9 @@ Function Add-pfSenseUser {
         [Int] $KeyLength = 2048,
         
         [Int] $LifeTime = 3650,
+
+        [ValidateSet('sha1', 'sha224', 'sha256', 'sha384', 'sha512')]
+        [String] $DigestAlgorithm = 'sha256',
         
         [Switch] $Quiet # No output upon completion
     )
@@ -269,11 +272,12 @@ Function Add-pfSenseUser {
         } # Change the utype to 'system' to create a protected system user
         
         $dictCertData = @{ # Extra form fields when requesting a certificate for the user
-            showcert = 'yes'
-            name     = "$($UserName)_cert"
-            caref    = $CA
-            keylen   = $KeyLength
-            lifetime = $LifeTime
+            showcert    = 'yes'
+            name        = "$($UserName)_cert"
+            caref       = $CA
+            keylen      = $KeyLength
+            lifetime    = $LifeTime
+            digest_alg  = $DigestAlgorithm
         }
             
         If ($Certificate) { # Should we request a cert from the CA?

--- a/pfSense/pfSense.psm1
+++ b/pfSense/pfSense.psm1
@@ -276,8 +276,8 @@ Function Add-pfSenseUser {
             name        = "$($UserName)_cert"
             caref       = $CA
             keylen      = $KeyLength
-            lifetime    = $LifeTime
             digest_alg  = $DigestAlgorithm
+            lifetime    = $LifeTime
         }
             
         If ($Certificate) { # Should we request a cert from the CA?


### PR DESCRIPTION
This change added digest_alg to the dictCertData hash table in order to fix issues with creating sha1 certs in the newest version of pfSense which is not supported. Also added a param to Add-pfSenseUser so this is selectable with a default of sha256.

